### PR TITLE
Fix string format in DeathServiceImpl::deleteDeathById logger message

### DIFF
--- a/src/main/java/com/medkha/lol_notes/services/impl/DeathServiceImpl.java
+++ b/src/main/java/com/medkha/lol_notes/services/impl/DeathServiceImpl.java
@@ -61,14 +61,9 @@ public class DeathServiceImpl implements DeathService{
 	@Override
 	public void deleteDeathById(Long id){
 		findById(id);
-		try {
 			deathRepository.deleteById(id);
-			String messageSuccess= String.format("deleteDeathById: death with id: %i was deleted successfully.", id);
+			String messageSuccess= String.format("deleteDeathById: death with id: %d was deleted successfully.", id);
 			log.info(messageSuccess);
-		}catch(IllegalArgumentException err) {
-			log.error("deleteDeathById: death id is null, so can't proceed.");
-			throw new IllegalArgumentException("death id is null, so can't proceed.");
-		}
 	}
 
 	@Override


### PR DESCRIPTION
Fix deleting a death, it throws before illegalArgumentException 'after' deleting the death due to the String.format method after the delete https://github.com/medkhabt/lol_notes/blob/a7a348545b7e6cccb24a4fc01503e1cc4e5ae4a7/src/main/java/com/medkha/lol_notes/services/impl/DeathServiceImpl.java#L66